### PR TITLE
Added capability to restrict moving between sections

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -36,7 +36,7 @@
 
 - (void)setEditing:(BOOL)editing {
     _editing = editing;
-    
+
     [self.tableView setEditing:editing animated:YES];
 }
 
@@ -543,7 +543,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     if (self.moveWithinSectionOnly && sourceIndexPath.section != proposedDestinationIndexPath.section) {
         return sourceIndexPath;
     }
-    return proposedDestinationIndexPath;
+    NSDictionary *section = self.sections[proposedDestinationIndexPath.section];
+    return [section[@"canMove"] boolValue] ? proposedDestinationIndexPath : sourceIndexPath;
 }
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath { //implement the delegate method

--- a/index.js
+++ b/index.js
@@ -134,7 +134,8 @@ class TableView extends React.Component {
                     footerHeight: section.props.footerHeight,
                     headerHeight: section.props.headerHeight,
                     items: items,
-                    count: count
+                    count: count,
+                    canMove: section.props.canMove,
                 });
             } else if (section && section.type==TableViewItem){
                 var el = extend({},section.props);


### PR DESCRIPTION
Restrict/Enable the ability to move cells between sections based on a flag in the section to indicate whether or not moving to that section is enabled.

The `canMove` flag on the section already existed and was used to indicate that any item in that section can be moved around. This PR now proposes that this flag be used to check whether the section can be used as a move target as well.